### PR TITLE
bugfix: 리뷰 조회 정렬 기준을 ID 내림차순으로 수정 (bug01)

### DIFF
--- a/src/main/java/com/doosan/review/repository/ReviewRepository.java
+++ b/src/main/java/com/doosan/review/repository/ReviewRepository.java
@@ -6,9 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {
-    List<Review> findByProductIdOrderByCreatedAtDesc(Long productId);
+    List<Review> findByProductIdOrderByIdDesc(Long productId); // 리뷰 Id 기준으로 내림차순 정렬
     boolean existsByProductIdAndUserId(Long productId, Long userId);
-
-
-    List<Review> findByProductId(Long productId);
 }

--- a/src/main/java/com/doosan/review/service/ReviewService.java
+++ b/src/main/java/com/doosan/review/service/ReviewService.java
@@ -30,7 +30,7 @@ public class ReviewService {
     @Transactional(readOnly = true)
     public ReviewResponse getReviews(Long productId, Long cursor, int size) {
         // 리뷰를 조회합니다. (최근 작성된 순으로)
-        List<Review> reviews = reviewRepository.findByProductIdOrderByCreatedAtDesc(productId);
+        List<Review> reviews = reviewRepository.findByProductIdOrderByIdDesc(productId);
 
         // 커서 기반 페이징 처리
         List<Review> pagedReviews = reviews.stream()

--- a/src/test/java/com/doosan/review/service/ReviewServiceTest.java
+++ b/src/test/java/com/doosan/review/service/ReviewServiceTest.java
@@ -60,7 +60,7 @@ public class ReviewServiceTest {
     @Test
     @Rollback(false)
     void testReviewCount() {
-        List<Review> reviews = reviewRepository.findByProductId(productId);
+        List<Review> reviews = reviewRepository.findByProductIdOrderByIdDesc(productId);
         assertThat(reviews.size()).isEqualTo(2);
     }
 


### PR DESCRIPTION
리뷰 조회 시 정렬 기준이 CreatedAt(생성일)로 잘못 설정되어 있어,
요구사항과 일치하지 않음.

### 해결 내용
- 정렬 기준을 ID 내림차순으로 변경.
- Repository 메서드 수정: `findByProductIdOrderByCreatedAtDesc` → `findByProductIdOrderByIdDesc`.

### 추가 확인 사항
- Service 계층에서 수정된 Repository 메서드 호출 정상 확인.