### PR TITLE
### JSON 날짜 포맷을 변경

### DIFF
--- a/src/main/java/com/doosan/review/config/JacksonConfig.java
+++ b/src/main/java/com/doosan/review/config/JacksonConfig.java
@@ -1,0 +1,25 @@
+package com.doosan.review.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JacksonConfig {
+
+    @Bean
+    public ObjectMapper objectMapper() {
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        // JavaTimeModule을 등록하여 LocalDateTime 직렬화 처리
+        objectMapper.registerModule(new JavaTimeModule());
+
+        // ISO-8601 포맷팅 적용
+        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+        return objectMapper;
+    }
+}
+

--- a/src/main/java/com/doosan/review/entity/Review.java
+++ b/src/main/java/com/doosan/review/entity/Review.java
@@ -1,6 +1,7 @@
 package com.doosan.review.entity;
 
 import com.fasterxml.jackson.annotation.JsonBackReference;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -37,6 +38,7 @@ public class Review {
     private String imageUrl;
 
     @Column(name = "created_at", nullable = false, updatable = false, columnDefinition = "DATETIME(6) DEFAULT CURRENT_TIMESTAMP")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", timezone = "UTC")
     private LocalDateTime createdAt;
 
     @PrePersist


### PR DESCRIPTION
### 문제 설명
과제의 리뷰 조회 API 응답 예시에서 createdAt 필드가 "createdAt": "2024-11-25T00:00:00.000Z" 이렇게 되어있고 이 형식은 ISO-8601 표준을 따르는 대표적인 날짜/시간 표현이므로 변경 필요

### 수정 사항
JacksonConfig.java를 추가하여 ObjectMapper를 전역적으로 설정:
JavaTimeModule 등록 및 ISO-8601 포맷 적용.
타임스탬프 대신 문자열로 날짜 직렬화.

Review.java 엔터티의 createdAt 필드에 @JsonFormat 추가:
ISO-8601 형식(yyyy-MM-dd'T'HH:mm:ss.SSS'Z')으로 JSON 직렬화. UTC 타임존을 명시하여 날짜 형식 표준화.

### 결과
API 응답에서 createdAt 필드가 ISO-8601 표준을 준수
Jackson의 글로벌 설정을 통해 JSON 직렬화 로직을 중앙화하여 유지보수성 향상